### PR TITLE
Alternative approach to conditional view transitions

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -27,12 +27,14 @@
   from { transform: translateX(-30px); }
 }
 
-/* only apply the view transition animation, when the navigation is _not_ coming _from_ a Task Show page */
-:not([data-from-path^="/tasks/"])::view-transition-old(aside) {
-  animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
-    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+::view-transition-old(aside):only-child {
+  animation:
+    90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    250ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
 }
-:not([data-from-path^="/tasks/"])::view-transition-new(aside) {
-  animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
-    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+
+::view-transition-new(aside):only-child {
+  animation:
+    210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    250ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,14 +2,5 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 
-navigation.addEventListener('navigate', (event) => {
-  const toUrl = new URL(event.destination.url);
-  const fromPath = location.pathname;
-
-  console.log(toUrl.pathname, fromPath)
-  document.documentElement.dataset.fromPath = fromPath;
-  document.documentElement.dataset.toPath = toUrl.pathname;
-});
-
 import "trix"
 import "@rails/actiontext"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -236,7 +236,7 @@
       <aside data-turbo-permanent class="p-2.5 pl-1.5">
         <!-- Secondary column (hidden on smaller screens) -->
         <div class="h-full bg-white rounded-xl overflow-hidden dark:bg-slate-900 dark:border-slate-800"
-             style="view-transition-name: aside">
+             <%= "style=\"view-transition-name: aside\"".html_safe if content_for?(:aside) %>>
           <% if content_for? :aside %>
             <%= yield :aside %>
           <% else %>


### PR DESCRIPTION
This pull request:

- conditionally adds a view-transition-name to the `aside` element, allowing us to determine when we're transitioning from a view with or without an existing `aside`
- uses the `:only-child` selector to customise the `aside` sliding transitions
- removes the navigation JS (no longer needed as we're using the markup to determine how we should transition)

This approach is beneficial, since it'll work for any case with an `aside`; there'll be no need to update the CSS when adding more URLs that need this behaviour.