### PR TITLE
Transition width

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -27,6 +27,11 @@
   from { transform: translateX(-30px); }
 }
 
+::view-transition-old(main),
+::view-transition-new(main) {
+  height: 100%;
+}
+
 /* only apply the view transition animation, when the navigation is _not_ coming _from_ a Task Show page */
 :not([data-from-path^="/tasks/"])::view-transition-old(aside) {
   animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,

--- a/app/views/tasks/_main.html.erb
+++ b/app/views/tasks/_main.html.erb
@@ -68,7 +68,7 @@
   </div>
 
   <div class="max-w-3xl px-12 mx-auto mt-6 mb-6">
-    <h1 class="text-5xl font-semibold">Inbox</h1>
+    <h1 class="text-5xl font-semibold [view-transition-name:heading] w-[fit-content]">Inbox</h1>
     <div class="@container mt-6">
       <p class="rounded-2xl p-2 @[668px]:rounded-full @[668px]:p-0 border-4 border-slate-100 bg-slate-100 dark:border-slate-800 dark:bg-slate-800 inline-flex items-center gap-2">
         <span class="size-8 min-w-8 bg-indigo-100 dark:bg-indigo-700/50 inline-flex items-center justify-center rounded-full">


### PR DESCRIPTION
Includes https://github.com/fractaledmind/turbolist/pull/18 and transitions the `main` width, i.e. it scales on the x-axis. This does mean that text will shrink and stretch, but this might be preferable to it scaling off to a corner.

https://github.com/fractaledmind/turbolist/assets/111734/c7951bff-895f-4d0d-bba9-df9ceb56861e

(Transitioning width can be tricky, particularly considering how the height of elements will likely increase as the width gets smaller due to wrapping)

